### PR TITLE
suit: Fix application only variants in suit AB manifests

### DIFF
--- a/samples/suit/ab/suit/nrf54h20/app_envelope.yaml.jinja2
+++ b/samples/suit/ab/suit/nrf54h20/app_envelope.yaml.jinja2
@@ -70,6 +70,11 @@ SUIT_Envelope_Tagged:
       - suit-condition-class-identifier: []
 
     suit-validate:
+    - suit-directive-set-component-index: {{ INACTIVE_IMG_IDX }}
+    # Declare inactive application partition as IPUC
+    - suit-directive-override-parameters:
+        suit-parameter-image-size:
+          raw: 0
     - suit-directive-set-component-index: {{ ACTIVE_IMG_IDX }}
     - suit-condition-image-match: []
 

--- a/samples/suit/ab/suit/nrf54h20/rad_envelope.yaml.jinja2
+++ b/samples/suit/ab/suit/nrf54h20/rad_envelope.yaml.jinja2
@@ -70,12 +70,20 @@ SUIT_Envelope_Tagged:
       - suit-condition-class-identifier: []
 
     suit-validate:
+    - suit-directive-set-component-index: {{ INACTIVE_IMG_IDX }}
+    # Declare inactive radio partition as IPUC
+    # This has to be done here to handle the case in which the
+    # radio for both A and B slots is damaged - the IPUC
+    # for the inactive radio component still has to be declared.
+    - suit-directive-override-parameters:
+        suit-parameter-image-size:
+          raw: 0
     - suit-directive-set-component-index: {{ ACTIVE_IMG_IDX }}
     - suit-condition-image-match: []
 
     suit-invoke:
     - suit-directive-set-component-index: {{ INACTIVE_IMG_IDX }}
-    # Declare inactive radio partition as IPUC
+    # Declare inactive application partition as IPUC
     - suit-directive-override-parameters:
         suit-parameter-image-size:
           raw: 0

--- a/samples/suit/ab/suit/nrf54h20/root_with_binary_nordic_top.yaml.jinja2
+++ b/samples/suit/ab/suit/nrf54h20/root_with_binary_nordic_top.yaml.jinja2
@@ -322,6 +322,16 @@ SUIT_Envelope_Tagged:
         - suit-directive-set-component-index: {{ APP_A_INSTLD_MFST_IDX }}
         - suit-condition-dependency-integrity: []
         - suit-directive-process-dependency: []
+        # Still run validate for the radio manifest, only in order to set
+        # the inactive radio partition as IPUC.
+        # The sequence will fail, but due to the soft-failure parameter
+        # it will not cause the whole current try-each sequence failure.
+        - suit-directive-run-sequence:
+          - suit-directive-set-component-index: {{ RAD_A_INSTLD_MFST_IDX }}
+          - suit-directive-override-parameters:
+              suit-parameter-soft-failure: True
+          - suit-condition-dependency-integrity: []
+          - suit-directive-process-dependency: []
 
       # Path B, just app image
       - - suit-directive-set-component-index: {{ VAR_BOOT_STATUS_IDX }}
@@ -331,6 +341,16 @@ SUIT_Envelope_Tagged:
         - suit-directive-set-component-index: {{ APP_B_INSTLD_MFST_IDX }}
         - suit-condition-dependency-integrity: []
         - suit-directive-process-dependency: []
+        # Still run validate for the radio manifest, only in order to set
+        # the inactive radio partition as IPUC.
+        # The sequence will fail, but due to the soft-failure parameter
+        # it will not cause the whole current try-each sequence failure.
+        - suit-directive-run-sequence:
+          - suit-directive-set-component-index: {{ RAD_B_INSTLD_MFST_IDX }}
+          - suit-directive-override-parameters:
+              suit-parameter-soft-failure: True
+          - suit-condition-dependency-integrity: []
+          - suit-directive-process-dependency: []
 
 
 {%- if APP_ROOT_VERSION is defined %}


### PR DESCRIPTION
The IPUC-s for radio were not created if the sample was run in an non-radio variant due to radio images being damaged.